### PR TITLE
Added same-release argument 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Using a git tag to work out the next release version is better than traditional 
 
 - If you need to support old release for example 7.0.x and tags for new realese 7.1.x already exist `-same-release` flag  will help to obtain version from 7.0.x release. If in pom file version is 7.0.0-SNAPSHOT and there are two tags 7.1.0 and 7.0.2 are exist command `jx-release-version` will return 7.1.1 but if we run `jx-release-version -same-release` it will return 7.0.3
 
-- If you need to get a release version `1.1.0` for older release and your last tag is `1.2.3` please change your Makefile or pom.xml to `1.1.0-SNAPSHOT` and run ``jx-release-version -same-release`
+- If you need to get a release version `1.1.0` for older release and your last tag is `1.2.3` please change your Makefile or pom.xml to `1.1.0-SNAPSHOT` and run `jx-release-version -same-release`
 
 ## Example Makefile
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Usage of jx-release-version:
   -gh-repository string
     	the git repository if not running from within a git project  e.g. fabric8
   -same-release 
-        get version with same Major and Minor version as current release added for support old releases: for example 7.0.x and tag for new realese 7.1.x already exist. With this `-same-release` argument next tag from 7.0.x will be returned          
+        get version with same Major and Minor version as current release, added for support old releases: for example 7.0.x and tag for new realese 7.1.x already exist. With this `-same-release` argument next tag from 7.0.x will be returned          
 ```
 
 ### FAQ

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Using a git tag to work out the next release version is better than traditional 
 
 - If your latest git tag is `1.2.3` and your Makefile or pom.xml is `2.0.0` then `jx-release-version` will return `2.0.0`
 
+- If you need to support old release for example 7.0.x and tags for new realese 7.1.x already exist `-same-release` flag  will help to obtain version from 7.0.x release. If in pom file version is 7.0.0-SNAPSHOT and there are two tags 7.1.0 and 7.0.2 are exist command `jx-release-version` will return 7.1.1 but if we run `jx-release-version -same-release` it will return 7.0.3
+
+- If you need to get a release version `1.1.0` for older release and your last tag is `1.2.3` please change your Makefile or pom.xml to `1.1.0-SNAPSHOT` and run ``jx-release-version -same-release`
+
 ## Example Makefile
 
 ```$xslt
@@ -65,6 +69,8 @@ Usage of jx-release-version:
     	the git repository owner if not running from within a git project  e.g. fabric8io
   -gh-repository string
     	the git repository if not running from within a git project  e.g. fabric8
+  -same-release 
+        get version with same Major and Minor version as current release added for support old releases: for example 7.0.x and tag for new realese 7.1.x already exist. With this `-same-release` argument next tag from 7.0.x will be returned          
 ```
 
 ### FAQ

--- a/README.md
+++ b/README.md
@@ -70,8 +70,7 @@ Usage of jx-release-version:
   -gh-repository string
     	the git repository if not running from within a git project  e.g. fabric8
   -same-release 
-        get version with same Major and Minor version as current release, added for support old releases: for example 7.0.x and tag for new realese 7.1.x already exist. With this `-same-release` argument next tag from 7.0.x will be returned          
-```
+        for support old releases: for example 7.0.x and tag for new realese 7.1.x already exist, with `-same-release` argument next version from 7.0.x will be returned ```
 
 ### FAQ
 

--- a/main.go
+++ b/main.go
@@ -214,9 +214,9 @@ func getLatestTag(c config) (string, error) {
 	var versions []*version.Version
 	for _, raw := range versionsRaw {
 		//if same-release argument is set work only with versions which Major and Minor versions are the same
-		if c.samerelease == true {
+		if c.samerelease {
 			same, _ := isMajorMinorTheSame(baseVersion, raw)
-			if same == true {
+			if same {
 				v, _ := version.NewVersion(raw)
 				if v != nil {
 					versions = append(versions, v)
@@ -228,9 +228,6 @@ func getLatestTag(c config) (string, error) {
 				versions = append(versions, v)
 			}
 		}
-	}
-	if c.debug == true {
-		fmt.Println("version collection size=", len(versions))
 	}
 
 	if len(versions) == 0 {

--- a/main.go
+++ b/main.go
@@ -213,8 +213,7 @@ func getLatestTag(c config) (string, error) {
 	// turn the array into a new collection of versions that we can sort
 	var versions []*version.Version
 	for _, raw := range versionsRaw {
-		//if same-release argiment is set work only with versions which Major and Minor versions are the same if no tag found
-		//like we have only 7.2.1 and 7.1.0 tags but our pom is 7.1.0-SNAPSHOT output will be 7.1.1
+		//if same-release argument is set work only with versions which Major and Minor versions are the same
 		if c.samerelease == true {
 			same, _ := isMajorMinorTheSame(baseVersion, raw)
 			if same == true {

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ func main() {
 	dir := flag.String("folder", ".", "the folder to look for files that contain a pom.xml or Makfile with the project version to bump")
 	owner := flag.String("gh-owner", "", "a github repository owner if not running from within a git project  e.g. fabric8io")
 	repo := flag.String("gh-repository", "", "a git repository if not running from within a git project  e.g. fabric8")
-	samerelease := flag.Bool("same-release", false, "get version with same major minor version as current release")
+	samerelease := flag.Bool("same-release", false, "get version with same Major and Minor version as current release, \n added for support old releases: for example 7.0.x and tag for new realese 7.1.x already exist.\n With this `-same-release` argument next tag from 7.0.x will be returned")
 
 	flag.Parse()
 

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ func main() {
 	dir := flag.String("folder", ".", "the folder to look for files that contain a pom.xml or Makfile with the project version to bump")
 	owner := flag.String("gh-owner", "", "a github repository owner if not running from within a git project  e.g. fabric8io")
 	repo := flag.String("gh-repository", "", "a git repository if not running from within a git project  e.g. fabric8")
-	samerelease := flag.Bool("same-release", false, "get version with same mafor minor version as current release")
+	samerelease := flag.Bool("same-release", false, "get version with same major minor version as current release")
 
 	flag.Parse()
 

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ func main() {
 	dir := flag.String("folder", ".", "the folder to look for files that contain a pom.xml or Makfile with the project version to bump")
 	owner := flag.String("gh-owner", "", "a github repository owner if not running from within a git project  e.g. fabric8io")
 	repo := flag.String("gh-repository", "", "a git repository if not running from within a git project  e.g. fabric8")
-	samerelease := flag.Bool("same-release", false, "get version with same Major and Minor version as current release, \n added for support old releases: for example 7.0.x and tag for new realese 7.1.x already exist.\n With this `-same-release` argument next tag from 7.0.x will be returned")
+	samerelease := flag.Bool("same-release", false, "for support old releases: for example 7.0.x and tag for new realese 7.1.x already exist, with `-same-release` argument next version from 7.0.x will be returned ")
 
 	flag.Parse()
 


### PR DESCRIPTION
Fixes https://github.com/jenkins-x/jx-release-version/issues/21
Added same-release argument if set work only with versions which Major and Minor versions are the same with base project version.
Like we have only 7.2.1 and 7.1.0 tags but our pom is 7.1.0-SNAPSHOT output will be 7.1.1
If no tag found with the same Major and Minor versions our pom is 7.1.0-SNAPSHOT output will be 7.1.0
