### PR TITLE
Feat/support setup py

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/xml"
+	"encoding/json"
 	"flag"
 	"os/exec"
 	"path/filepath"
@@ -126,6 +127,21 @@ func getVersion(c config) (string, error) {
 			return project.Version, nil
 		}
 	}
+
+	pkg, err := ioutil.ReadFile(c.dir + string(filepath.Separator) + "package.json")
+    if err == nil {
+        if c.debug {
+            fmt.Println("found package.json")
+        }
+        var project Project
+        json.Unmarshal(pkg, &project)
+        if project.Version != "" {
+            if c.debug {
+                fmt.Println(fmt.Sprintf("existing version %v", project.Version))
+            }
+            return project.Version, nil
+        }
+    }
 
 	return "", errors.New("no recognised file to obtain current version from")
 }

--- a/main_test.go
+++ b/main_test.go
@@ -42,6 +42,42 @@ func TestPackageJSON(t *testing.T) {
 	assert.Equal(t, "1.2.3", v, "error with getVersion for a package.json")
 }
 
+func TestSetupPyStandard(t *testing.T) {
+
+	c := config{
+		dir: "test-resources/python/standard",
+	}
+	v, err := getVersion(c)
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, "4.5.6", v, "error with getVersion for a setup.py")
+}
+
+func TestSetupPyNested(t *testing.T) {
+
+	c := config{
+		dir: "test-resources/python/nested",
+	}
+	v, err := getVersion(c)
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, "4.5.6", v, "error with getVersion for a setup.py")
+}
+
+func TestSetupPyOneLine(t *testing.T) {
+
+	c := config{
+		dir: "test-resources/python/one_line",
+	}
+	v, err := getVersion(c)
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, "4.5.6", v, "error with getVersion for a setup.py")
+}
+
 func TestChart(t *testing.T) {
 
 	c := config{

--- a/main_test.go
+++ b/main_test.go
@@ -30,6 +30,18 @@ func TestPomXML(t *testing.T) {
 	assert.Equal(t, "1.0-SNAPSHOT", v, "error with getVersion for a pom.xml")
 }
 
+func TestPackageJSON(t *testing.T) {
+
+	c := config{
+		dir: "test-resources/package",
+	}
+	v, err := getVersion(c)
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, "1.2.3", v, "error with getVersion for a package.json")
+}
+
 func TestChart(t *testing.T) {
 
 	c := config{

--- a/test-resources/package/package.json
+++ b/test-resources/package/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "test-package",
+  "version": "1.2.3"
+}

--- a/test-resources/python/nested/setup.py
+++ b/test-resources/python/nested/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup
+
+
+def call_setup():
+    setup(
+        name='setup-test',
+        version='4.5.6',
+        description='A test setup.py script for testing',
+    )
+
+call_setup()

--- a/test-resources/python/one_line/setup.py
+++ b/test-resources/python/one_line/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup(name='setup-test', version='4.5.6', description='A test setup.py script for testing',)

--- a/test-resources/python/standard/setup.py
+++ b/test-resources/python/standard/setup.py
@@ -1,0 +1,7 @@
+from setuptools import setup
+
+setup(
+    name='setup-test',
+    version='4.5.6',
+    description='A test setup.py script for testing',
+)


### PR DESCRIPTION
This PR adds support for obtaining the version from setup.py scripts.  Because they are not well-formatted the way pom.xml or Makefiles are there are some pretty wonky regex's being used to locate the call to `setup(...)` and pull the `version` argument out.

I added multiple setup.py files to the test directory to test for edge cases.