### PR TITLE
feat: Added setup.py support

### DIFF
--- a/main.go
+++ b/main.go
@@ -178,6 +178,35 @@ func getVersion(c config) (string, error) {
 		}
 	}
 
+	s, err := ioutil.ReadFile(c.dir + string(filepath.Separator) + "setup.py")
+	if err == nil {
+		if c.debug {
+			fmt.Println("Found setup.py")
+		}
+
+		// Regex to find the call to `setup(..., version='1.2.3', ...)`
+		re := regexp.MustCompile("setup\\((.|\\n)*version\\s*=\\s*'(\\d|\\.)*'([^\\)]|\\n)*\\)")
+		setup_call_bytes := re.Find(s)
+
+		if len(setup_call_bytes) > 0 {
+
+			// Regex to find the argument `version='1.2.3'`
+			version_re := regexp.MustCompile("version\\s*=\\s*'(\\d*|\\.)*'")
+
+			version := string(version_re.Find(setup_call_bytes))
+
+			parts := strings.Split(strings.Replace(version, " ", "", -1), "=")
+			v := strings.TrimPrefix(strings.TrimSuffix(parts[1], "'"), "'")
+
+			if v != "" {
+				if c.debug {
+					fmt.Println(fmt.Sprintf("existing Makefile version %v", v))
+				}
+				return v, nil
+			}
+		}
+	}
+
 	p, err := ioutil.ReadFile(filepath.Join(c.dir, "pom.xml"))
 	if err == nil {
 		if c.debug {

--- a/main_test.go
+++ b/main_test.go
@@ -32,15 +32,15 @@ func TestAutomakefile(t *testing.T) {
 
 func TestCMakefile(t *testing.T) {
 
-       c := config{
-               dir: "test-resources/cmake",
-       }
+	c := config{
+		dir: "test-resources/cmake",
+	}
 
-       v, err := getVersion(c)
+	v, err := getVersion(c)
 
-       assert.NoError(t, err)
+	assert.NoError(t, err)
 
-       assert.Equal(t, "1.2.0-SNAPSHOT", v, "error with getVersion for a CMakeLists.txt")
+	assert.Equal(t, "1.2.0-SNAPSHOT", v, "error with getVersion for a CMakeLists.txt")
 }
 
 func TestPomXML(t *testing.T) {
@@ -79,6 +79,42 @@ func TestChart(t *testing.T) {
 	assert.Equal(t, "0.0.1-SNAPSHOT", v, "error with getVersion for a Chart.yaml")
 }
 */
+
+func TestSetupPyStandard(t *testing.T) {
+
+	c := config{
+		dir: "test-resources/python/standard",
+	}
+	v, err := getVersion(c)
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, "4.5.6", v, "error with getVersion for a setup.py")
+}
+
+func TestSetupPyNested(t *testing.T) {
+
+	c := config{
+		dir: "test-resources/python/nested",
+	}
+	v, err := getVersion(c)
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, "4.5.6", v, "error with getVersion for a setup.py")
+}
+
+func TestSetupPyOneLine(t *testing.T) {
+
+	c := config{
+		dir: "test-resources/python/one_line",
+	}
+	v, err := getVersion(c)
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, "4.5.6", v, "error with getVersion for a setup.py")
+}
 
 func TestGetGitTag(t *testing.T) {
 	c := config{

--- a/test-resources/python/nested/setup.py
+++ b/test-resources/python/nested/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup
+
+
+def call_setup():
+    setup(
+        name='setup-test',
+        version='4.5.6',
+        description='A test setup.py script for testing',
+    )
+
+call_setup()

--- a/test-resources/python/one_line/setup.py
+++ b/test-resources/python/one_line/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup(name='setup-test', version='4.5.6', description='A test setup.py script for testing',)

--- a/test-resources/python/standard/setup.py
+++ b/test-resources/python/standard/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup
+
+# Red Herring
+version='1.2.3'
+
+setup(
+    name='setup-test',
+    version = '4.5.6',
+    description='A test setup.py script for testing',
+)


### PR DESCRIPTION
This PR adds support for obtaining the version from setup.py scripts. Because they are not well-formatted the way pom.xml or Makefiles are there are some pretty wonky regex's being used to locate the call to setup(...) and pull the version argument out.

I added multiple setup.py files to the test directory to test for edge cases.